### PR TITLE
Initialize grpc_byte_buffer to nullptr

### DIFF
--- a/src/hhvm/ext/grpc/call.cpp
+++ b/src/hhvm/ext/grpc/call.cpp
@@ -127,7 +127,7 @@ Object HHVM_METHOD(Call, startBatch,
   grpc_status_code status;
   grpc_slice recv_status_details = grpc_empty_slice();
   grpc_slice send_status_details = grpc_empty_slice();
-  grpc_byte_buffer *message;
+  grpc_byte_buffer *message = nullptr;
   int cancelled;
   grpc_call_error error;
 


### PR DESCRIPTION
at the beginning of `Call->startBatch`, `message` is uninitialized and not guaranteed to be any particular value.
```cpp
   grpc_byte_buffer *message;
```

`grpc_byte_buffer_destroy` will only return early if the pointer it is passed is null: https://github.com/grpc/grpc/blob/master/src/core/lib/surface/byte_buffer.c#L71
if the value is stack junk, it can crash dereferencing it or will call `gpr_free` against an address it didn't allocate.

in the normal case, grpc will allocate the actual buffer and change `message` to point to it. This sets that up:
```cpp
         ops[op_num].data.recv_message.recv_message = &message;
```

if anything happens that prevents grpc from modifying `message` through that double-pointer, such as `goto cleanup` happening when  `GRPC_OP_RECV_MESSAGE` is one of the keys, `grpc_byte_buffer_destroy` will attempt to destroy the garbage `message` is pointing at for the reasons described above.